### PR TITLE
PreFarmerMinionHarvestEvent + Pitcher / Torchflower crop support

### DIFF
--- a/api/src/main/kotlin/com/artillexstudios/axminions/api/events/PreFarmerMinionHarvestEvent.kt
+++ b/api/src/main/kotlin/com/artillexstudios/axminions/api/events/PreFarmerMinionHarvestEvent.kt
@@ -24,10 +24,6 @@ class PreFarmerMinionHarvestEvent(minion: Minion, val block: Block) : MinionEven
         return isCancelled
     }
 
-    fun getHarvestBlock(): Block {
-        return block
-    }
-
     override fun setCancelled(cancelled: Boolean) {
         isCancelled = cancelled
     }

--- a/api/src/main/kotlin/com/artillexstudios/axminions/api/events/PreFarmerMinionHarvestEvent.kt
+++ b/api/src/main/kotlin/com/artillexstudios/axminions/api/events/PreFarmerMinionHarvestEvent.kt
@@ -28,10 +28,6 @@ class PreFarmerMinionHarvestEvent(minion: Minion, val block: Block) : MinionEven
         return block
     }
 
-    fun setType(): Block {
-        return block
-    }
-
     override fun setCancelled(cancelled: Boolean) {
         isCancelled = cancelled
     }

--- a/api/src/main/kotlin/com/artillexstudios/axminions/api/events/PreFarmerMinionHarvestEvent.kt
+++ b/api/src/main/kotlin/com/artillexstudios/axminions/api/events/PreFarmerMinionHarvestEvent.kt
@@ -1,0 +1,38 @@
+package com.artillexstudios.axminions.api.events
+
+import com.artillexstudios.axminions.api.minions.Minion
+import org.bukkit.block.Block
+import org.bukkit.event.Cancellable
+import org.bukkit.event.HandlerList
+
+class PreFarmerMinionHarvestEvent(minion: Minion, val block: Block) : MinionEvent(minion), Cancellable {
+    companion object {
+        private val handlerList = HandlerList()
+
+        @JvmStatic
+        fun getHandlerList(): HandlerList = handlerList
+    }
+
+    private var isCancelled = false
+
+
+    override fun getHandlers(): HandlerList {
+        return handlerList
+    }
+
+    override fun isCancelled(): Boolean {
+        return isCancelled
+    }
+
+    fun getHarvestBlock(): Block {
+        return block
+    }
+
+    fun setType(): Block {
+        return block
+    }
+
+    override fun setCancelled(cancelled: Boolean) {
+        isCancelled = cancelled
+    }
+}

--- a/common/src/main/kotlin/com/artillexstudios/axminions/minions/miniontype/FarmerMinionType.kt
+++ b/common/src/main/kotlin/com/artillexstudios/axminions/minions/miniontype/FarmerMinionType.kt
@@ -1,6 +1,7 @@
 package com.artillexstudios.axminions.minions.miniontype
 
 import com.artillexstudios.axminions.AxMinionsPlugin
+import com.artillexstudios.axminions.api.events.PreFarmerMinionHarvestEvent
 import com.artillexstudios.axminions.api.minions.Minion
 import com.artillexstudios.axminions.api.minions.miniontype.MinionType
 import com.artillexstudios.axminions.api.utils.LocationUtils
@@ -9,6 +10,7 @@ import com.artillexstudios.axminions.api.utils.fastFor
 import com.artillexstudios.axminions.api.warnings.Warnings
 import com.artillexstudios.axminions.minions.MinionTicker
 import dev.lone.itemsadder.api.CustomBlock
+import org.bukkit.Bukkit
 import kotlin.math.roundToInt
 import org.bukkit.Material
 import org.bukkit.block.data.Ageable
@@ -65,6 +67,9 @@ class FarmerMinionType : MinionType("farmer", AxMinionsPlugin.INSTANCE.getResour
             if (AxMinionsPlugin.integrations.itemsAdderIntegration) {
                 val customBlock = CustomBlock.byAlreadyPlaced(block)
                 if (customBlock !== null) {
+                    val preHarvestEvent = PreFarmerMinionHarvestEvent(minion, block)
+                    Bukkit.getPluginManager().callEvent(preHarvestEvent)
+                    if (preHarvestEvent.isCancelled) return@fastFor
                     val blockDrops = customBlock.getLoot(minion.getTool(), false)
                     size += blockDrops.size
                     drops.addAll(blockDrops)
@@ -75,6 +80,9 @@ class FarmerMinionType : MinionType("farmer", AxMinionsPlugin.INSTANCE.getResour
 
             when (block.type) {
                 Material.CACTUS, Material.SUGAR_CANE, Material.BAMBOO -> {
+                    val preHarvestEvent = PreFarmerMinionHarvestEvent(minion, block)
+                    Bukkit.getPluginManager().callEvent(preHarvestEvent)
+                    if (preHarvestEvent.isCancelled) return@fastFor
                     MinionUtils.getPlant(block).fastFor {
                         val blockDrops = it.getDrops(minion.getTool())
                         size++
@@ -83,16 +91,22 @@ class FarmerMinionType : MinionType("farmer", AxMinionsPlugin.INSTANCE.getResour
                     }
                 }
 
-                Material.MELON, Material.PUMPKIN -> {
+                Material.MELON, Material.PUMPKIN, Material.TORCHFLOWER -> {
+                    val preHarvestEvent = PreFarmerMinionHarvestEvent(minion, block)
+                    Bukkit.getPluginManager().callEvent(preHarvestEvent)
+                    if (preHarvestEvent.isCancelled) return@fastFor
                     val blockDrops = block.getDrops(minion.getTool())
                     size++
                     drops.addAll(blockDrops)
                     block.type = Material.AIR
                 }
 
-                Material.COCOA_BEANS, Material.COCOA, Material.NETHER_WART, Material.WHEAT, Material.CARROTS, Material.BEETROOTS, Material.POTATOES -> {
+                Material.COCOA_BEANS, Material.COCOA, Material.NETHER_WART, Material.WHEAT, Material.CARROTS, Material.BEETROOTS, Material.POTATOES, Material.PITCHER_CROP -> {
                     val ageable = block.blockData as Ageable
                     if (ageable.age != ageable.maximumAge) return@fastFor
+                    val preHarvestEvent = PreFarmerMinionHarvestEvent(minion, block)
+                    Bukkit.getPluginManager().callEvent(preHarvestEvent)
+                    if (preHarvestEvent.isCancelled) return@fastFor
                     val blockDrops = block.getDrops(minion.getTool())
                     size++
                     drops.addAll(blockDrops)
@@ -103,6 +117,9 @@ class FarmerMinionType : MinionType("farmer", AxMinionsPlugin.INSTANCE.getResour
                 Material.SWEET_BERRY_BUSH -> {
                     val ageable = block.blockData as Ageable
                     if (ageable.age != ageable.maximumAge) return@fastFor
+                    val preHarvestEvent = PreFarmerMinionHarvestEvent(minion, block)
+                    Bukkit.getPluginManager().callEvent(preHarvestEvent)
+                    if (preHarvestEvent.isCancelled) return@fastFor
                     val blockDrops = block.getDrops(minion.getTool())
                     size++
                     drops.addAll(blockDrops)


### PR DESCRIPTION
I needed PreFarmerMinionHarvestEvent to replant torchflower crops again. So that's why I added it. Also I added torchflower and pitcher blocks to farmer minion's block list since they are growing from a seed.