### PR TITLE
Skip stacked mobs from nametag check

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DiscordProjectSettings">
     <option name="show" value="ASK" />

--- a/common/src/main/kotlin/com/artillexstudios/axminions/commands/AxMinionsCommand.kt
+++ b/common/src/main/kotlin/com/artillexstudios/axminions/commands/AxMinionsCommand.kt
@@ -1,29 +1,21 @@
 package com.artillexstudios.axminions.commands
 
-import com.artillexstudios.axapi.scheduler.Scheduler
 import com.artillexstudios.axapi.utils.ItemBuilder
 import com.artillexstudios.axapi.utils.StringUtils
 import com.artillexstudios.axminions.AxMinionsPlugin
 import com.artillexstudios.axminions.api.AxMinionsAPI
 import com.artillexstudios.axminions.api.config.Config
 import com.artillexstudios.axminions.api.config.Messages
-import com.artillexstudios.axminions.api.data.DataHandler
 import com.artillexstudios.axminions.api.minions.miniontype.MinionType
 import com.artillexstudios.axminions.api.minions.miniontype.MinionTypes
 import com.artillexstudios.axminions.api.utils.fastFor
 import com.artillexstudios.axminions.converter.LitMinionsConverter
-import com.artillexstudios.axminions.integrations.island.SuperiorSkyBlock2Integration
-import com.artillexstudios.axminions.minions.Minions
-import com.bgsoftware.superiorskyblock.api.SuperiorSkyblockAPI
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
-import org.bukkit.Chunk
 import org.bukkit.OfflinePlayer
-import org.bukkit.World.Environment
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 import revxrsal.commands.annotation.*
 import revxrsal.commands.bukkit.annotation.CommandPermission
-import java.util.concurrent.CompletableFuture
 
 @Command("axminions", "minion", "minions")
 class AxMinionsCommand {

--- a/common/src/main/kotlin/com/artillexstudios/axminions/integrations/Integrations.kt
+++ b/common/src/main/kotlin/com/artillexstudios/axminions/integrations/Integrations.kt
@@ -147,6 +147,7 @@ class Integrations : Integrations {
 
         if (Bukkit.getPluginManager().getPlugin("BentoBox") != null) {
             register(BentoBoxIntegration())
+            register(com.artillexstudios.axminions.integrations.island.BentoBoxIntegration())
             Bukkit.getConsoleSender()
                 .sendMessage(StringUtils.formatToString("<#33FF33>[AxMinions] Hooked into BentoBox!"))
         }

--- a/common/src/main/kotlin/com/artillexstudios/axminions/integrations/Integrations.kt
+++ b/common/src/main/kotlin/com/artillexstudios/axminions/integrations/Integrations.kt
@@ -189,12 +189,6 @@ class Integrations : Integrations {
                 .sendMessage(StringUtils.formatToString("<#33FF33>[AxMinions] Hooked into ItemsAdder!"))
         }
 
-        if (Bukkit.getPluginManager().getPlugin("ItemsAdder") != null) {
-            itemsAdderIntegration = true
-            Bukkit.getConsoleSender()
-                .sendMessage(StringUtils.formatToString("<#33FF33>[AxMinions] Hooked into ItemsAdder!"))
-        }
-
         if (Bukkit.getPluginManager().getPlugin("Towny") != null) {
             register(TownyIntegration())
         }

--- a/common/src/main/kotlin/com/artillexstudios/axminions/integrations/island/BentoBoxIntegration.kt
+++ b/common/src/main/kotlin/com/artillexstudios/axminions/integrations/island/BentoBoxIntegration.kt
@@ -1,0 +1,32 @@
+package com.artillexstudios.axminions.integrations.island
+
+import com.artillexstudios.axminions.api.integrations.types.IslandIntegration
+import org.bukkit.Location
+import org.bukkit.block.Block
+import world.bentobox.bentobox.BentoBox
+
+class BentoBoxIntegration : IslandIntegration {
+
+    override fun getIslandAt(location: Location): String {
+        val island = BentoBox.getInstance().islandsManager.islandCache.getIslandAt(location)
+
+        if (island !== null) {
+            return island.uniqueId
+        }
+
+        return ""
+    }
+
+    override fun getExtra(location: Location): Int {
+        return 0
+    }
+
+
+    override fun handleBlockBreak(block: Block) {
+
+    }
+
+    override fun register() {
+
+    }
+}

--- a/common/src/main/kotlin/com/artillexstudios/axminions/minions/miniontype/SlayerMinionType.kt
+++ b/common/src/main/kotlin/com/artillexstudios/axminions/minions/miniontype/SlayerMinionType.kt
@@ -77,7 +77,7 @@ class SlayerMinionType : MinionType("slayer", AxMinionsPlugin.INSTANCE.getResour
                 return@fastFor
             }
 
-            if (!getConfig().getBoolean("damage-renamed") && it.customName != null) {
+            if (!getConfig().getBoolean("damage-renamed") && it.customName != null && AxMinionsPlugin.integrations.getStackerIntegration().getStackSize(it) <= 1) {
                 return@fastFor
             }
 


### PR DESCRIPTION
there is still issue that `NMSHandler.get().attack(minion, it)` does nothing while WildStacker is loaded.